### PR TITLE
Add oxygen gas definitions

### DIFF
--- a/src/PlasmaSpecies.jl
+++ b/src/PlasmaSpecies.jl
@@ -8,7 +8,7 @@ export Positive, Negative, Neutral, Charge, Species
 export ispositive, isnegative, isneutral
 
 include("gas.jl")
-export Gas, StringGas, DiNitrogen, Nitrogen
+export Gas, StringGas, DiNitrogen, Nitrogen, DiOxygen, Oxygen
 
 include("electronic_state.jl")
 export ElectronicState, StringElectronicState

--- a/src/gas.jl
+++ b/src/gas.jl
@@ -3,12 +3,17 @@ abstract type Gas end
 
 include("gases/electron.jl")
 include("gases/nitrogen.jl")
+include("gases/oxygen.jl")
 const REGISTERED_GASES = Dict(
     "e" => Electron,
     "N" => Nitrogen,
     "N2" => DiNitrogen,
     "N3" => TriNitrogen,
     "N4" => TetraNitrogen,
+    "O" => Oxygen,
+    "O2" => DiOxygen,
+    "O3" => TriOxygen,
+    "O4" => TetraOxygen,
 )
 Gas(x) = haskey(REGISTERED_GASES, x) ? REGISTERED_GASES[x]() : StringGas(x)
 

--- a/src/gases/oxygen.jl
+++ b/src/gases/oxygen.jl
@@ -1,0 +1,49 @@
+"""
+    Oxygen <: Gas
+
+Atomic oxygen.
+Registered label: `O`
+
+"""
+struct Oxygen <: Gas end
+Base.show(io::IO, ::Oxygen) = print(io,"O")
+Base.print(io::IO, ::Oxygen) = print(io, "O")
+mass(::Oxygen) = 16*1.67e-27 # kg
+
+"""
+    DiOxygen <: Gas
+
+Molecular oxygen.
+Registered label: `O2`
+
+"""
+struct DiOxygen <: Gas end
+Base.show(io::IO, ::DiOxygen) = print(io,"O₂")
+Base.print(io::IO, ::DiOxygen) = print(io,"O2")
+mass(::DiOxygen) = mass(Oxygen())*2 # kg
+
+
+"""
+    TriOxygen <: Gas
+
+Tri atomic oxygen (ozone).
+Registered label: `O3`
+
+"""
+struct TriOxygen <: Gas end
+Base.show(io::IO, ::TriOxygen) = print(io,"O₃")
+Base.print(io::IO, ::TriOxygen) = print(io, "O3")
+mass(::TriOxygen) = mass(Oxygen())*3 # kg
+
+"""
+    TetraOxygen <: Gas
+
+Tetra atomic oxygen.
+Registered label: `O4`
+
+"""
+struct TetraOxygen <: Gas end
+Base.show(io::IO, ::TetraOxygen) = print(io,"O₄")
+Base.print(io::IO, ::TetraOxygen) = print(io, "O4")
+mass(::TetraOxygen) = mass(Oxygen())*4 # kg
+

--- a/test/test_mass.jl
+++ b/test/test_mass.jl
@@ -8,3 +8,9 @@ using Test
 @test mass(Species("N2(-)")) ≈ mass(Species("N2")) + mass(Species("e"))
 @test mass(Species("N2(+)")) ≈ mass(Species("N2")) - mass(Species("e"))
 
+@test mass(Species("O2")) == mass(DiOxygen())
+@test mass(Species("O2(X,v=0)")) == mass(Species("O2"))
+@test mass(Species("O2(X,v=0)")) == mass(p"O2")
+@test mass(Species("O2(-)")) ≈ mass(Species("O2")) + mass(Species("e"))
+@test mass(Species("O2(+)")) ≈ mass(Species("O2")) - mass(Species("e"))
+


### PR DESCRIPTION
## Summary
- add gas definitions for atomic and molecular oxygen species
- register the new oxygen species so they can be parsed from string labels
- extend mass tests to cover oxygen species

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_e_68cd2c2b5038832fb4a79369eeaa7876